### PR TITLE
Whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,22 @@ MyAttributedObject.new(
 SimpleFoo.new(bar: 12) == SimpleFoo.new(bar: 12)
 ```
 
+### Whitelist
+```ruby
+class MyAttributedObject
+  include AttributedObject::Strict
+
+  attribute :planet, :string, whitelist: ['Earth', 'Mars']
+end
+```
+
 ### Strict Type Checking
 ```ruby
 class MyTypedAttributedObject
   include AttributedObject::Strict
 
   attribute :first, :string, disallow: nil
-  attribute :second, MyAttributedObject, default: nil 
+  attribute :second, MyAttributedObject, default: nil
 end
 
 # Works
@@ -103,7 +112,7 @@ MyTypedAttributedObject.new(
   )
 )
 
-# Supported Types: 
+# Supported Types:
 # :string
 # :boolean
 # :integer
@@ -115,7 +124,7 @@ MyTypedAttributedObject.new(
 # ArrayOf(:integer)
 # HashOf(:symbol, :string)
 # Instances of AttributedObject::Type (example: lib/attributed_object/types/array_of.rb)
-# any Class 
+# any Class
 ```
 
 ## Coercion
@@ -155,7 +164,7 @@ end
     default_to: AttributedObject::Unset, # AttributedObject::Unset | any value | AttributedObject::TypeDefaults
     ignore_extra_keys: false, # false | true
     coerce_blanks_to_nil: false, # false | true
-    disallow: AttributedObject::Unset, # AttributedObject::Unset | any value 
+    disallow: AttributedObject::Unset, # AttributedObject::Unset | any value
 }
 ```
 
@@ -167,7 +176,7 @@ class Defaulting
   include AttributedObject::Strict
   attributed_object default_to: nil
 
-  attribute :foo 
+  attribute :foo
 end
 Defaulting.new.foo # => nil
 
@@ -206,7 +215,7 @@ class WithExtraOptions
   include AttributedObject::Strict
   attributed_object ignore_extra_keys: true
 
-  attribute :foo 
+  attribute :foo
 end
 WithExtraOptions.new(foo: 'asd', something: 'bar') # this will not throw an error, usually it would
 ```
@@ -222,7 +231,7 @@ class WithExtraOptions
   include AttributedObject::Strict
   attributed_object disallow: nil
 
-  attribute :foo 
+  attribute :foo
 end
 WithExtraOptions.new(foo: nil) # this will not throw an error
 ```

--- a/lib/attributed_object.rb
+++ b/lib/attributed_object.rb
@@ -64,4 +64,3 @@ module AttributedObject
   class ConfigurationError < Error
   end
 end
-

--- a/lib/attributed_object/base.rb
+++ b/lib/attributed_object/base.rb
@@ -14,7 +14,8 @@ module AttributedObject
           default_to: Unset,
           ignore_extra_keys: false,
           coerce_blanks_to_nil: false,
-          disallow: Unset
+          disallow: Unset,
+          whitelist: Unset
         }.merge(parent_ops)
       end
 
@@ -25,7 +26,7 @@ module AttributedObject
         @attribute_defs = parent_defs.clone
       end
 
-      def attribute(attr_name, type_info = Unset, default: Unset, disallow: Unset)
+      def attribute(attr_name, type_info = Unset, default: Unset, disallow: Unset, whitelist: Unset)
         if default == Unset
           default_to = attributed_object_options.fetch(:default_to)
 
@@ -37,13 +38,18 @@ module AttributedObject
         if disallow == Unset
           disallow = attributed_object_options.fetch(:disallow)
         end
-        
+
+        if whitelist == Unset
+          whitelist = attributed_object_options.fetch(:whitelist)
+        end
+
         _attributed_object_check_type_supported!(type_info)
 
         attribute_defs[attr_name] = {
           type_info: type_info,
           default: default,
           disallow: disallow,
+          whitelist: whitelist
         }
 
         attr_writer attr_name
@@ -92,6 +98,11 @@ module AttributedObject
           if opts[:type_info] != Unset && symbolized_args[name] != nil
             symbolized_args[name] = _attributed_object_on_init_attribute(opts[:type_info], symbolized_args[name], name: name, args: args)
           end
+
+          if opts[:whitelist] != Unset && !opts[:whitelist].include?(symbolized_args[name])
+            raise DisallowedValueError.new(self.class, name, args)
+          end
+
           self.send("#{name}=", symbolized_args[name])
         }
       end
@@ -108,4 +119,3 @@ module AttributedObject
     end
   end
 end
-

--- a/lib/attributed_object/strict.rb
+++ b/lib/attributed_object/strict.rb
@@ -25,4 +25,3 @@ module AttributedObject
     end
   end
 end
-

--- a/lib/attributed_object/version.rb
+++ b/lib/attributed_object/version.rb
@@ -1,3 +1,3 @@
 module AttributedObject
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/attributed_object_spec.rb
+++ b/spec/attributed_object_spec.rb
@@ -30,7 +30,7 @@ describe AttributedObject do
     include AttributedObject::Strict
 
     PLANET_EARTH = 'earth'.freeze
-    PLANET_MARS = 'earth'.freeze
+    PLANET_MARS = 'mars'.freeze
 
     attribute :planet, :string, whitelist: [PLANET_EARTH, PLANET_MARS]
   end

--- a/spec/attributed_object_spec.rb
+++ b/spec/attributed_object_spec.rb
@@ -26,6 +26,15 @@ describe AttributedObject do
     end
   end
 
+  class AttributedObjectWithWhitelist
+    include AttributedObject::Strict
+
+    PLANET_EARTH = 'earth'.freeze
+    PLANET_MARS = 'earth'.freeze
+
+    attribute :planet, :string, whitelist: [PLANET_EARTH, PLANET_MARS]
+  end
+
   class ChildFoo < DefaultFoo
     attribute :lollipop, default: "lecker"
   end
@@ -42,6 +51,17 @@ describe AttributedObject do
 
     it 'can be controlled to not allow explicit nil' do
       expect { DisallowingNil.new(bar: nil).bar }.to raise_error(AttributedObject::DisallowedValueError)
+    end
+  end
+
+  describe 'whitelist' do
+    it 'allows whitelisted values' do
+      object = AttributedObjectWithWhitelist.new(planet: AttributedObjectWithWhitelist::PLANET_EARTH)
+      expect(object.planet).to eq(AttributedObjectWithWhitelist::PLANET_EARTH)
+    end
+
+    it 'crashes when provided with not-whitelisted value' do
+      expect { AttributedObjectWithWhitelist.new(planet: 'sun') }.to raise_error(AttributedObject::DisallowedValueError)
     end
   end
 
@@ -167,7 +187,7 @@ describe AttributedObject do
           attribute :bar, :integer
           attribute :has_other_disallow, :integer, disallow: 0
         end
-    
+
         expect { FooWithExtra.new(bar: 1, has_other_disallow: 1) }.not_to raise_error
         expect { FooWithExtra.new(bar: 1, has_other_disallow: nil) }.not_to raise_error
         expect { FooWithExtra.new(bar: nil, has_other_disallow: 1) }.to raise_error(AttributedObject::DisallowedValueError)
@@ -203,23 +223,23 @@ describe AttributedObject do
       expect(SimpleFoo.new(bar: 77)).to_not eq(SimpleFoo.new(bar: 12))
     end
   end
-  
+
   describe 'attribute storage' do
     class InnerStructureFoo
       include AttributedObject::Coerce
       attribute :bar, :string, default: 'default'
       attribute :foo, :string, default: 'default'
       attribute :number, :integer, default: 0
-      
+
       def foo=(f)
         @foo = "prefix-#{f}-suffix"
       end
-      
+
       def number=(n)
         @number = n+1
       end
     end
-    
+
     describe '#attributes' do
       it 'returns the attributes as hash' do
         expect(InnerStructureFoo.new(bar: 'hi').attributes).to eq(
@@ -229,15 +249,15 @@ describe AttributedObject do
         )
       end
     end
-    
+
     it 'stores the data in instance vars' do
       expect(InnerStructureFoo.new(bar: 'hi').instance_variable_get('@bar')).to eq('hi')
     end
-    
+
     it 'uses setters' do
       expect(InnerStructureFoo.new(foo: 'middel').foo).to eq('prefix-middel-suffix')
     end
-    
+
     it 'uses setters after coercion' do
       expect(InnerStructureFoo.new(number: '42').number).to eq(43)
     end


### PR DESCRIPTION
```ruby
require 'attributed_object'

class TestClass
  include AttributedObject::Strict

  CONST_WORLD = 'world'.freeze
  CONST_MARS = 'mars'.freeze

  attribute :planet, :string, whitelist: [CONST_WORLD, CONST_MARS]
end

TestClass.new(planet: TestClass::CONST_WORLD) # => Object instance with .planet = 'world'
TestClass.new(planet: 'sun') # => AttributedObject::DisallowedValueError
```